### PR TITLE
Agrega links clicables al perfil

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,11 +78,13 @@
                         <h5 class="text-muted">Senior Full Stack Developer</h5>
                         <hr>
                         <div class="contact-info">
-                            <p><i class="fas fa-envelope me-2"></i> adrianferrert@gmail.com</p>
-                            <p><i class="fas fa-phone me-2"></i> +34 669808666</p>
-                            <p><i class="fas fa-map-marker-alt me-2"></i> Barcelona, Spain</p>
-                            <p><i class="fab fa-github me-2"></i> github.com/adrifther</p>
-                            <p><i class="fab fa-linkedin me-2"></i> linkedin.com/in/adrian-ferrer-torres</p>
+                          <p>
+                            📧 <a href="mailto:adrianferrert@gmail.com">adrianferrert@gmail.com</a><br>
+                            📞 <a href="tel:+34669808666">+34 669808666</a><br>
+                            📍 <span>Barcelona, Spain</span><br>
+                            🐱 <a href="https://github.com/adrifther" target="_blank">github.com/adrifther</a><br>
+                            💼 <a href="https://www.linkedin.com/in/adrian-ferrer-torres" target="_blank">linkedin.com/in/adrian-ferrer-torres</a>
+                          </p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Se añadieron etiquetas <a> para hacer clic en el email, teléfono, GitHub y LinkedIn.